### PR TITLE
Aligned player Hitboxes with direction and height

### DIFF
--- a/Assets/Scenes/Development/TestLevel.unity
+++ b/Assets/Scenes/Development/TestLevel.unity
@@ -898,7 +898,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1975322593}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1, y: 0, z: 0}
+  m_LocalPosition: {x: -0.5, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -958,12 +958,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1366145622}
     - target: {fileID: 2162224656283483558, guid: bfcbbe56022dc6643854f54deddf060a, type: 3}
+      propertyPath: attackPositionX
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2162224656283483558, guid: bfcbbe56022dc6643854f54deddf060a, type: 3}
       propertyPath: basicMeleeRange
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2162224656283483558, guid: bfcbbe56022dc6643854f54deddf060a, type: 3}
       propertyPath: switchMeleeRange
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2162224656283483558, guid: bfcbbe56022dc6643854f54deddf060a, type: 3}
       propertyPath: enemyLayers.m_Bits

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using UnityEditor;
 using UnityEngine;
@@ -19,7 +20,7 @@ public class PlayerController : MonoBehaviour
     [SerializeField]
     private LayerMask enemyLayers;
     //floats
-    [SerializeField] 
+    [SerializeField]
     private float speed = 5f;
     [SerializeField]
     private float jumpForce = 7.5f;
@@ -35,6 +36,8 @@ public class PlayerController : MonoBehaviour
     private float maxJumpTime = 0.2f;
     [SerializeField]
     private float basicMeleeRange = 1f;
+    [SerializeField]
+    private float attackPositionX = 1f;
     [SerializeField]
     private float switchMeleeRange = 1f;
     //integers
@@ -61,6 +64,7 @@ public class PlayerController : MonoBehaviour
     private Animator animator;
     private Rigidbody2D myRb;
     private Vector2 moveInput;
+    private Dictionary<bool, int> boolToInt = new Dictionary<bool, int> { { false, -1 }, {true, 1} };
 
     //Happens when gathering values before Start
     private void Awake()
@@ -90,6 +94,7 @@ public class PlayerController : MonoBehaviour
         if (absVelocityX > 0.01) 
         {
             sprite.flipX = newVelocity.x > 0;
+            attackPoint.position = new Vector2(myRb.position.x + boolToInt[newVelocity.x > 0] * attackPositionX, attackPoint.position.y);
         }
 
 
@@ -228,7 +233,7 @@ public class PlayerController : MonoBehaviour
     }
 
     //you can uncomment this script to see the hitbox for the Melee attacks
-    /*
+    
     private void OnDrawGizmosSelected()
     {
         if (attackPoint == null)
@@ -237,6 +242,6 @@ public class PlayerController : MonoBehaviour
         Gizmos.DrawWireSphere(attackPoint.position, basicMeleeRange);
     }
 
-    */
+ 
 
 }


### PR DESCRIPTION
Shortened player hitboxes to align with height of character from new animations. Additionally the position of the hitboxes now appear in front of the player depending on the direction the player is facing.